### PR TITLE
Script runs in bash rather than sh

### DIFF
--- a/walk-rpde.sh
+++ b/walk-rpde.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # required commands: awk, curl, jq, tee
 


### PR DESCRIPTION
Due to new string substitution stuff, this can only work in bash.
Otherwise, I got `./walk-rpde.sh: 22: ./walk-rpde.sh: Bad substitution`