### PR TITLE
Posix-compatible 'string starts with' test

### DIFF
--- a/walk-rpde.sh
+++ b/walk-rpde.sh
@@ -19,9 +19,8 @@ do
   page_padded=$(printf '%0*d\n' ${#max} $page)
   set -- $(curl -L -sS "$1" | jq '.' | tee rpde-$page_padded.json | jq -r '.next, (.items | length)')
   printf 'got page with next url: %s, num items: %s\n' "$1" $2
-  if [ "${1%${1/?}}"x = '/x' ]
-  then
+  case $1 in /*)
     set -- $base$1 $2
-  fi
+  esac
   page=$((page=page+1))
 done


### PR DESCRIPTION
@lukehesluke this PR replaces your bash PR.. I've changed the 'string starts with' test to be POSIX-compatible (I tested with `dash` in addition to `bash`), so it should work on your laptop now..

n.b. I assumed the test I originally used would be POSIX-compatible, based on this SO answer:

https://serverfault.com/a/252406

But it seems this is not the case, hence I've changed to the alternative `case` form, which seems to do the trick.